### PR TITLE
use new website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gumdrop 
 
 See the [Metaplex Docs](https://docs.metaplex.com/airdrops/create-gumdrop) and the
-[About page](https://lwus.github.io/metaplex/) for more information.
+[About page](https://gumdrop.metaplex.com/) for more information.
 
 ## Setup
 

--- a/packages/cli/src/gumdrop-cli.ts
+++ b/packages/cli/src/gumdrop-cli.ts
@@ -95,7 +95,7 @@ programCommand('create')
   .option(
     '--host <string>',
     'Website to claim gumdrop',
-    'https://lwus.github.io/metaplex',
+    'https://gumdrop.metaplex.com/',
   )
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   .action(async (options, cmd) => {

--- a/packages/gumdrop/README.md
+++ b/packages/gumdrop/README.md
@@ -8,4 +8,4 @@ echo 'REACT_APP_WEB_HOME="/gumdrop"' > .env
 ```
 
 See the [Metaplex Docs](https://docs.metaplex.com/airdrops/create-gumdrop) and the
-[About page](https://lwus.github.io/metaplex/) for more information.
+[About page](https://gumdrop.metaplex.com/) for more information.


### PR DESCRIPTION
Currently we the default URL is https://lwus.github.io/metaplex/ which is the old website where e.g. the candy integration is not working currently.

With this PR it is pointed to the newer officially hosted website.