### PR TITLE
added null check on array

### DIFF
--- a/packages/gumdrop/src/utils/transactions.ts
+++ b/packages/gumdrop/src/utils/transactions.ts
@@ -30,7 +30,7 @@ export const envFor = (connection: Connection): string => {
   const endpoint = (connection as any)._rpcEndpoint;
   const regex = /https:\/\/metaplex.([^.]*).rpcpool.com/;
   const match = endpoint.match(regex);
-  if (match[1]) {
+  if (match && match[1]) {
     return match[1];
   }
   return 'mainnet-beta';


### PR DESCRIPTION
While deploying to mainnet I got the following error when trying to mint (the mint would work, but an error toast is shown).
![image](https://user-images.githubusercontent.com/10220149/186747375-7265136a-9a45-4d04-8d9f-5bce89118a25.png)

This error was also seen by discord user erikiado.

The change should stop the error caused by accessing the [1] position on a null array